### PR TITLE
Configure ngrok exe location

### DIFF
--- a/src/NgrokExtensionsSolution/NgrokExtensions/NgrokExtensions.csproj
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/NgrokExtensions.csproj
@@ -55,6 +55,9 @@
     <Compile Include="NgrokTunnelApiRequest.cs" />
     <Compile Include="NgrokTunnelsApiResponse.cs" />
     <Compile Include="NgrokUtils.cs" />
+    <Compile Include="OptionsPageGrid.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StartTunnel.cs" />
     <Compile Include="StartTunnelPackage.cs" />

--- a/src/NgrokExtensionsSolution/NgrokExtensions/OptionsPageGrid.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/OptionsPageGrid.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NgrokExtensions
+{
+    public class OptionsPageGrid : Microsoft.VisualStudio.Shell.DialogPage
+    {
+        private string executablePath = "";
+
+        [Category("ngrok")]
+        [DisplayName("Executable Path")]
+        [Description("Full path to the ngrok executable")]
+        public string ExecutablePath
+        {
+            get { return executablePath; }
+            set { executablePath = value; }
+        }
+    }
+}

--- a/src/NgrokExtensionsSolution/NgrokExtensions/StartTunnel.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/StartTunnel.cs
@@ -97,10 +97,13 @@ namespace NgrokExtensions
                 ShowErrorMessage(message);
             });
 
+            OptionsPageGrid page = (OptionsPageGrid)_package.GetDialogPage(typeof(OptionsPageGrid));
+
             ThreadHelper.JoinableTaskFactory.Run(async delegate
             {
                 await TaskScheduler.Default;
-                await ngrok.StartTunnelsAsync();
+
+                await ngrok.StartTunnelsAsync(page.ExecutablePath);
             });
         }
 

--- a/src/NgrokExtensionsSolution/NgrokExtensions/StartTunnelPackage.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/StartTunnelPackage.cs
@@ -29,6 +29,7 @@ namespace NgrokExtensions
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)] // Info on this package for Help/About
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(StartTunnelPackage.PackageGuidString)]
+    [ProvideOptionPage(typeof(OptionsPageGrid), "ngrok", "Options", 0, 0, true)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     public sealed class StartTunnelPackage : Package
     {
@@ -36,6 +37,15 @@ namespace NgrokExtensions
         /// StartTunnelPackage GUID string.
         /// </summary>
         public const string PackageGuidString = "9f845cfc-84ef-4aac-9826-d46a83744fb4";
+
+        public string ExecutablePath
+        {
+            get
+            {
+                OptionsPageGrid page = (OptionsPageGrid)this.GetDialogPage(typeof(OptionsPageGrid));
+                return page.ExecutablePath;
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StartTunnel"/> class.


### PR DESCRIPTION
This PR adds a new OptionsGridPage that lets a user configure an explicit path to their ngrok exe instead of simply relying on the PATH env var.  If the user doesn't configure the path explicitly the add in still falls back to trying to launch the exe using the PATH.