### PR TITLE
Upgrade vsix to support VS2019

### DIFF
--- a/src/NgrokExtensionsSolution/NgrokExtensions/source.extension.vsixmanifest
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/source.extension.vsixmanifest
@@ -11,14 +11,13 @@
     <Tags>Visual Studio, Extension, Web</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
   </Dependencies>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
See: https://blogs.msdn.microsoft.com/visualstudio/2018/09/26/how-to-upgrade-extensions-to-support-visual-studio-2019/

Fixes #25 