### PR TITLE
Support https

### DIFF
--- a/src/NgrokExtensionsSolution/NgrokExtensions.Test/FakeNgrokProcess.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions.Test/FakeNgrokProcess.cs
@@ -4,8 +4,11 @@ namespace NgrokExtensions.Test
 {
     public class FakeNgrokProcess : NgrokProcess
     {
-        public FakeNgrokProcess(string exePath) : base(exePath)
+        private readonly string _stdout;
+
+        public FakeNgrokProcess(string exePath, string stdout) : base(exePath)
         {
+            _stdout = stdout;
         }
 
         public int StartCount { get; set; } = 0;
@@ -15,6 +18,16 @@ namespace NgrokExtensions.Test
         {
             StartCount++;
             LastProcessStartInfo = pi;
+        }
+
+        protected override string GetStandardOutput()
+        {
+            return _stdout;
+        }
+
+        protected override void WaitForExit()
+        {
+            // nothing to wait for in testing
         }
     }
 }

--- a/src/NgrokExtensionsSolution/NgrokExtensions.Test/NgrokExtensions.Test.csproj
+++ b/src/NgrokExtensionsSolution/NgrokExtensions.Test/NgrokExtensions.Test.csproj
@@ -71,6 +71,7 @@
     <Compile Include="NgrokUtilsTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NgrokInstallerTest.cs" />
+    <Compile Include="WebAppConfigTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NgrokExtensions\NgrokExtensions.csproj">

--- a/src/NgrokExtensionsSolution/NgrokExtensions.Test/NgrokUtilsTest.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions.Test/NgrokUtilsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -21,11 +22,13 @@ namespace NgrokExtensions.Test
         private NgrokTunnelApiRequest _expectedRequest;
         private NgrokTunnelsApiResponse _emptyTunnelsResponse;
         private int _expectedProcessCount;
+        private string _tempFile;
 
         [TestInitialize]
         public void Initialize()
         {
             _expectedProcessCount = 0;
+            _tempFile = Path.GetTempFileName();
             _mockHttp = new MockHttpMessageHandler();
             _client = new HttpClient(_mockHttp);
 
@@ -65,13 +68,17 @@ namespace NgrokExtensions.Test
 
         private void InitializeUtils(string stdout)
         {
-            _ngrokProcess = new FakeNgrokProcess("", stdout);
-            _utils = new NgrokUtils(_webApps, "", _mockErrorDisplay.Object.ShowError, _client, _ngrokProcess);
+            _ngrokProcess = new FakeNgrokProcess(_tempFile, stdout);
+            _utils = new NgrokUtils(_webApps, _tempFile, _mockErrorDisplay.Object.ShowError, _client, _ngrokProcess);
         }
 
         [TestCleanup]
         public void Cleanup()
         {
+            if(File.Exists(_tempFile))
+            {
+                File.Delete(_tempFile);
+            }
             Assert.AreEqual(_expectedProcessCount, _ngrokProcess.StartCount);
             _mockHttp.VerifyNoOutstandingExpectation();
         }

--- a/src/NgrokExtensionsSolution/NgrokExtensions.Test/Properties/AssemblyInfo.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions.Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -32,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.12.0")]
-[assembly: AssemblyFileVersion("0.9.12.0")]
+[assembly: AssemblyVersion("0.9.13.0")]
+[assembly: AssemblyFileVersion("0.9.13.0")]

--- a/src/NgrokExtensionsSolution/NgrokExtensions.Test/WebAppConfigTest.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions.Test/WebAppConfigTest.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NgrokExtensions.Test
+{
+    /// <summary>
+    /// Summary description for WebAppConfigTest
+    /// </summary>
+    [TestClass]
+    public class WebAppConfigTest
+    {
+        [TestMethod]
+        public void TestUrlNoHttps()
+        {
+            var webApp = new WebAppConfig("http://localhost:1234/");
+            Assert.AreEqual("localhost:1234", webApp.NgrokAddress);
+        }
+
+        [TestMethod]
+        public void TestPortNumberOnly()
+        {
+            var webApp = new WebAppConfig("1234");
+            Assert.AreEqual("localhost:1234", webApp.NgrokAddress);
+        }
+
+        [TestMethod]
+        public void TestUrlWithHttps()
+        {
+            var webApp = new WebAppConfig("https://localhost:1234/");
+            Assert.AreEqual("https://localhost:1234", webApp.NgrokAddress);
+        }
+
+        [TestMethod]
+        public void TestUrlWithHttpsAndLongPath()
+        {
+            var webApp = new WebAppConfig("https://localhost:1234/foo/bar");
+            Assert.AreEqual("https://localhost:1234", webApp.NgrokAddress);
+        }
+
+        [TestMethod]
+        public void TestUrlWithHttpsAndNoPath()
+        {
+            var webApp = new WebAppConfig("https://localhost:1234");
+            Assert.AreEqual("https://localhost:1234", webApp.NgrokAddress);
+        }
+    }
+}

--- a/src/NgrokExtensionsSolution/NgrokExtensions/LICENSE.txt
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/LICENSE.txt
@@ -1,6 +1,6 @@
 ﻿MIT License
 
-Copyright (c) 2016 David Prothero
+Copyright (c) 2019 David Prothero
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/NgrokExtensionsSolution/NgrokExtensions/NgrokErrorApiResult.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/NgrokErrorApiResult.cs
@@ -1,6 +1,6 @@
 ﻿// This file is licensed to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-// Copyright (c) 2016 David Prothero
+// Copyright (c) 2019 David Prothero
 
 namespace NgrokExtensions
 {

--- a/src/NgrokExtensionsSolution/NgrokExtensions/NgrokExtensions.csproj
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/NgrokExtensions.csproj
@@ -64,6 +64,9 @@
     <StartAction>Program</StartAction>
     <StartProgram>$(VS140COMNTOOLS)\..\IDE\devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
+    <CopyVsixExtensionFiles>False</CopyVsixExtensionFiles>
+    <CopyVsixExtensionLocation>
+    </CopyVsixExtensionLocation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/NgrokExtensionsSolution/NgrokExtensions/NgrokTunnelApiRequest.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/NgrokTunnelApiRequest.cs
@@ -1,6 +1,6 @@
 ﻿// This file is licensed to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-// Copyright (c) 2016 David Prothero
+// Copyright (c) 2019 David Prothero
 
 namespace NgrokExtensions
 {

--- a/src/NgrokExtensionsSolution/NgrokExtensions/NgrokTunnelsApiResponse.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/NgrokTunnelsApiResponse.cs
@@ -1,6 +1,6 @@
 ﻿// This file is licensed to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-// Copyright (c) 2016 David Prothero
+// Copyright (c) 2019 David Prothero
 
 namespace NgrokExtensions
 {

--- a/src/NgrokExtensionsSolution/NgrokExtensions/NgrokUtils.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/NgrokUtils.cs
@@ -1,6 +1,6 @@
 ﻿// This file is licensed to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-// Copyright (c) 2016 David Prothero
+// Copyright (c) 2019 David Prothero
 
 using System;
 using System.Collections.Generic;

--- a/src/NgrokExtensionsSolution/NgrokExtensions/NgrokUtils.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/NgrokUtils.cs
@@ -8,7 +8,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -19,6 +18,7 @@ namespace NgrokExtensions
     public class NgrokUtils
     {
         public const string NgrokNotFoundMessage = "ngrok executable not found. Configure the path in the via the add-in options or add the location to your PATH.";
+        private static Version MinimumVersion = new Version("2.3.34");
         private readonly Dictionary<string, WebAppConfig> _webApps;
         private readonly Func<string, Task> _showErrorFunc;
         private readonly HttpClient _ngrokApi;
@@ -40,7 +40,13 @@ namespace NgrokExtensions
 
         public bool NgrokIsInstalled()
         {
-            return _ngrokProcess.IsInstalled();
+            if (!_ngrokProcess.IsInstalled()) return false;
+
+            var versionString = _ngrokProcess.GetNgrokVersion();
+            if (versionString == null) return false;
+
+            var version = new Version(versionString);
+            return version.CompareTo(MinimumVersion) >= 0;
         }
 
         public async Task StartTunnelsAsync()
@@ -124,7 +130,7 @@ namespace NgrokExtensions
 
         private async Task StartNgrokTunnelAsync(string projectName, WebAppConfig config)
         {
-            var addr = $"localhost:{config.PortNumber}";
+            var addr = config.NgrokAddress;
             if (!TunnelAlreadyExists(addr))
             {
                 await CreateTunnelAsync(projectName, config, addr);
@@ -136,6 +142,11 @@ namespace NgrokExtensions
             return _tunnels.Any(t => t.config.addr == addr);
         }
 
+        private string StripProtocol(string addr)
+        {
+            return addr.Replace("https://", "");
+        }
+
         private async Task CreateTunnelAsync(string projectName, WebAppConfig config, string addr, bool retry = false)
         {
             var request = new NgrokTunnelApiRequest
@@ -143,7 +154,7 @@ namespace NgrokExtensions
                 name = projectName,
                 addr = addr,
                 proto = "http",
-                host_header = addr
+                host_header = StripProtocol(addr)
             };
             if (!string.IsNullOrEmpty(config.SubDomain))
             {

--- a/src/NgrokExtensionsSolution/NgrokExtensions/Properties/AssemblyInfo.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -29,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.12.0")]
-[assembly: AssemblyFileVersion("0.9.12.0")]
+[assembly: AssemblyVersion("0.9.13.0")]
+[assembly: AssemblyFileVersion("0.9.13.0")]

--- a/src/NgrokExtensionsSolution/NgrokExtensions/StartTunnel.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/StartTunnel.cs
@@ -8,7 +8,6 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using EnvDTE;
@@ -33,8 +32,6 @@ namespace NgrokExtensions
             "FileName",    // Azure functions if ends with '.funproj'
             "ProjectUrl"
         };
-
-        private static readonly Regex NumberPattern = new Regex(@"\d+");
 
         public const int CommandId = 0x0100;
         private const string NgrokSubdomainSettingName = "ngrok.subdomain";
@@ -106,7 +103,7 @@ namespace NgrokExtensions
             if (!ngrok.NgrokIsInstalled())
             {
                 if (AskUserYesNoQuestion(
-                    "Ngrok is not installed. Would you like me to download it from ngrok.com and install it for you?"))
+                    "Ngrok 2.3.34 or above is not installed. Would you like me to download it from ngrok.com and install it for you?"))
                 {
                     installPlease = true;
                 }
@@ -182,14 +179,14 @@ namespace NgrokExtensions
                     DebugWriteProp(prop);
                     if (!PortPropertyNames.Contains(prop.Name)) continue;
 
-                    var webApp = new WebAppConfig();
+                    WebAppConfig webApp;
 
                     if (prop.Name == "FileName")
                     {
                         if (prop.Value.ToString().EndsWith(".funproj"))
                         {
                             // Azure Functions app - use port 7071
-                            webApp.PortNumber = 7071;
+                            webApp = new WebAppConfig("7071");
                             LoadOptionsFromAppSettingsJson(project, webApp);
                         }
                         else
@@ -199,9 +196,8 @@ namespace NgrokExtensions
                     }
                     else
                     {
-                        var match = NumberPattern.Match(prop.Value.ToString());
-                        if (!match.Success) continue;
-                        webApp.PortNumber = int.Parse(match.Value);
+                        webApp = new WebAppConfig(prop.Value.ToString());
+                        if (!webApp.IsValid) continue;
                         if (IsAspNetCoreProject(prop.Name))
                         {
                             LoadOptionsFromAppSettingsJson(project, webApp);

--- a/src/NgrokExtensionsSolution/NgrokExtensions/StartTunnel.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/StartTunnel.cs
@@ -1,6 +1,6 @@
 ﻿// This file is licensed to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-// Copyright (c) 2016 David Prothero
+// Copyright (c) 2019 David Prothero
 
 using System;
 using System.Collections.Generic;

--- a/src/NgrokExtensionsSolution/NgrokExtensions/StartTunnelPackage.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/StartTunnelPackage.cs
@@ -1,6 +1,6 @@
 ﻿// This file is licensed to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-// Copyright (c) 2016 David Prothero
+// Copyright (c) 2019 David Prothero
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;

--- a/src/NgrokExtensionsSolution/NgrokExtensions/WebAppConfig.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/WebAppConfig.cs
@@ -1,6 +1,6 @@
 ﻿// This file is licensed to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-// Copyright (c) 2016 David Prothero
+// Copyright (c) 2019 David Prothero
 
 namespace NgrokExtensions
 {

--- a/src/NgrokExtensionsSolution/NgrokExtensions/WebAppConfig.cs
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/WebAppConfig.cs
@@ -2,12 +2,41 @@
 // See the LICENSE file in the project root for more information.
 // Copyright (c) 2019 David Prothero
 
+using System.Text.RegularExpressions;
+
 namespace NgrokExtensions
 {
     public class WebAppConfig
     {
-        public int PortNumber { get; set; }
+        private static readonly Regex HttpsPattern = new Regex(@"^https://[^/]+");
+        private static readonly Regex NumberPattern = new Regex(@"\d+");
+
+        public bool IsValid
+        {
+            get
+            {
+                return NgrokAddress != null;
+            }
+        }
+
+        public string NgrokAddress { get; }
         public string SubDomain { get; set; }
         public string PublicUrl { get; set; }
+
+        public WebAppConfig(string settingValue)
+        {
+            NgrokAddress = ParseNgrokAddress(settingValue);
+        }
+
+        private string ParseNgrokAddress(string settingValue)
+        {
+            var match = HttpsPattern.Match(settingValue);
+            if (match.Success) return match.Value;
+
+            match = NumberPattern.Match(settingValue);
+            if (match.Success) return $"localhost:{match.Value}";
+
+            return null;
+        }
     }
 }

--- a/src/NgrokExtensionsSolution/NgrokExtensions/source.extension.vsixmanifest
+++ b/src/NgrokExtensionsSolution/NgrokExtensions/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NgrokExtensions.David Prothero.1af4dbfe-1c37-44bd-b491-5acee6064583" Version="0.9.12" Language="en-US" Publisher="David Prothero" />
+    <Identity Id="NgrokExtensions.David Prothero.1af4dbfe-1c37-44bd-b491-5acee6064583" Version="0.9.13" Language="en-US" Publisher="David Prothero" />
     <DisplayName>Ngrok Extensions</DisplayName>
     <Description>Use ngrok quickly and easily from within Visual Studio. ngrok allows you to expose a local server behind a NAT or firewall to the internet. "Demo without deploying."</Description>
     <MoreInfo>https://github.com/dprothero/NgrokExtensions</MoreInfo>


### PR DESCRIPTION
Since new project templates enable https by default on ASP.NET projects, we need to support https on the local development server.

Supporting https isn't available in all versions of ngrok, so we also need to ensure that we are running a version that supports it.

[Test VSIX](https://ci.appveyor.com/api/buildjobs/cf3njdnj629b3a4y/artifacts/src%2FNgrokExtensionsSolution%2FNgrokExtensions%2Fbin%2FRelease%2FNgrokExtensions.vsix)